### PR TITLE
Fixed auction glow and hide your gold

### DIFF
--- a/source/core/source/auction.js
+++ b/source/core/source/auction.js
@@ -66,7 +66,7 @@ var gca_auction = {
 		for (var i = items.length - 1; i >= 0; i--) {
 			// Get elements
 			tooltipElement = items[i].getElementsByTagName("div")[1];
-			itemElement = items[i].getElementsByTagName("div")[2];
+			itemElement = items[i].getElementsByTagName("div")[1];
 			// Render shadow
 			gca_tools.item.shadow.add(itemElement, tooltipElement);
 		}


### PR DESCRIPTION
Hi,

GameForge did an update before few days and broke hide your gold by moving the "div"s order, this small change fixes it.