### PR TITLE
(Optional) Refresh when statistics reset

### DIFF
--- a/source/core/source/global.js
+++ b/source/core/source/global.js
@@ -4751,6 +4751,7 @@ var gca_global = {
 				button2.addEventListener('click', function(){
 					gca_data.section.set('data', 'gold_exp_data', []);
 					gca_notifications.success(gca_locale.get('global', 'gold_exp_data_reset'));
+					window.location.reload();
 				
 			});
 


### PR DESCRIPTION
This is purely optional (you don't have to add it, if you don't want to), and perhaps there is a better way to do this, that you are aware of.

When you reset it, it will stay there, until the page is refreshed, so that's why I added a reload.