### PR TITLE
add colors to smelting tooltip

### DIFF
--- a/source/core/source/forge.js
+++ b/source/core/source/forge.js
@@ -501,7 +501,17 @@ var gca_forge = {
 			smeltTimes.data = [];// EndTime, Name
 			for(var i = 0; i < window.slotsData.length; i++) {
 				if (typeof window.slotsData[i]['forge_slots.uend'] !== "undefined") {
-					smeltTimes.data.push([window.slotsData[i]['forge_slots.uend'], window.slotsData[i].item.name]);
+					var colorFromQuality = (() => {
+						switch (window.slotsData[i].item.data.quality) {
+							case 0: return 'lime'
+							case 1: return '#5159f7'
+							case 2: return '#e303e0'
+							case 3: return '#FF6A00'
+							case 4: return '#FF0000'
+							default: return 'white'
+						}
+					})()
+					smeltTimes.data.push([window.slotsData[i]['forge_slots.uend'], window.slotsData[i].item.name, colorFromQuality]);
 				}
 			}
 			gca_data.section.set("timers", "smelt_times", smeltTimes);

--- a/source/core/source/global.js
+++ b/source/core/source/global.js
@@ -2930,14 +2930,14 @@ var gca_global = {
 				var current = new Date(); current = current.getTime();
 				var tooltip = '[[';
 				if(smeltTimes.data.length>0){
-					tooltip += '[["'+smeltTimes.translation[0]+'","'+smeltTimes.translation[1]+'"],["#FF6A00; text-shadow: 0 0 2px #000, 0 0 2px #FF6A00","#FF6A00; text-shadow: 0 0 2px #000, 0 0 2px #FF6A00"]]';
+					tooltip += '[["'+smeltTimes.translation[0]+'","'+smeltTimes.translation[1]+'"],["#FFF; text-shadow: 0 0 2px #000, 0 0 2px #FFF","#FFF; text-shadow: 0 0 2px #000, 0 0 2px #FFF"]]';
 					for(let i=0;i<smeltTimes.data.length;i++){
 						if(smeltTimes.data[i][0]*1000<=current){
 							type = 'green';
 							gca_notifications.success( smeltTimes.translation[0]+': '+smeltTimes.data[i][1]+'\n'+smeltTimes.translation[2], gca_getPage.link({"mod":"forge","submod":"smeltery"}) );
 							tooltip += ',[["'+smeltTimes.data[i][1]+'","'+smeltTimes.translation[2]+'"],["#DDD","#00ff00"]]';
 						}else{
-							tooltip += ',[["'+smeltTimes.data[i][1]+'","'+gca_tools.time.msToString(smeltTimes.data[i][0]*1000-current)+'"],["#DDD","#DDD"]]';
+							tooltip += ',[["'+smeltTimes.data[i][1]+'","'+gca_tools.time.msToString(smeltTimes.data[i][0]*1000-current)+`"],["${smeltTimes.data[i][2]}","${smeltTimes.data[i][2]}"]]`;
 						}
 					}
 					if(forgeTimes.data.length>0){tooltip += ',';}


### PR DESCRIPTION
Another idea I had that I think can improve user experience. The smelting tooltip would be color coded based on quality.

Unless there's already a way to see this info?

<img width="556" alt="imagem" src="https://user-images.githubusercontent.com/8149533/147884043-aec043ae-6e2a-4d7e-a243-420773da0761.png">

Need help testing as I'm not sure the qualities are all correctly mapped.