### PR TITLE
add colors to forging tooltip

### DIFF
--- a/source/core/source/forge.js
+++ b/source/core/source/forge.js
@@ -481,8 +481,9 @@ var gca_forge = {
 			let current = new Date().getTime();
 			for (let i = 0; i < window.slotsData.length; i++) {
 				if (typeof window.slotsData[i]['forge_slots.uend'] !== "undefined") {
+					let itemQuality = window.slotsData[i].item.data.quality;
 					if(window.slotsData[i]['forge_slots.uend'] * 1000 > current)
-						forgeTimes.data.push([window.slotsData[i]['forge_slots.uend'], window.slotsData[i].item.name]);
+						forgeTimes.data.push([window.slotsData[i]['forge_slots.uend'], window.slotsData[i].item.name, itemQuality]);
 				}
 			}
 			gca_data.section.set("timers", "forge_times", forgeTimes);

--- a/source/core/source/global.js
+++ b/source/core/source/global.js
@@ -2946,14 +2946,17 @@ var gca_global = {
 					if(forgeTimes.data.length>0){tooltip += ',';}
 				}
 				if(forgeTimes.data.length>0){
-					tooltip += '[["'+forgeTimes.translation[0]+'","'+forgeTimes.translation[1]+'"],["#FF6A00; font-size:12px; text-shadow: 0 0 2px #000, 0 0 2px #FF6A00","#FF6A00; font-size:12px; text-shadow: 0 0 2px #000, 0 0 2px #FF6A00"]]';
+					tooltip += '[["'+forgeTimes.translation[0]+'","'+forgeTimes.translation[1]+'"],["#FFF; font-size:12px; text-shadow: 0 0 2px #000, 0 0 2px #FFF","#FFF; font-size:12px; text-shadow: 0 0 2px #000, 0 0 2px #FFF"]]';
 					for(let i=0;i<forgeTimes.data.length;i++){
 						if(forgeTimes.data[i][0]*1000<=current){
 							type = 'green';
 							gca_notifications.success(forgeTimes.translation[0]+': '+forgeTimes.data[i][1]+'\n'+forgeTimes.translation[2]);
 							tooltip += ',[["'+forgeTimes.data[i][1]+'","'+forgeTimes.translation[2]+'"],["#DDD","#00ff00"]]';
 						}else{
-							tooltip += ',[["'+forgeTimes.data[i][1]+'","'+gca_tools.time.msToString(forgeTimes.data[i][0]*1000-current)+'"],["#DDD","#DDD"]]';
+							let qualityColor = gca_tools.item.shadow.getColor(forgeTimes.data[i][2], true);
+							if (qualityColor == false)
+								qualityColor == 'white'; // compatibility with old data
+							tooltip += ',[["'+forgeTimes.data[i][1]+'","'+gca_tools.time.msToString(forgeTimes.data[i][0]*1000-current)+`"],["${qualityColor}","${qualityColor}"]]`;
 						}
 					}
 				}


### PR DESCRIPTION
<img width="536" alt="imagem" src="https://user-images.githubusercontent.com/8149533/147888360-54c36bdc-7d4e-454d-ace6-85b8c4412237.png">

I've had to duplicate the "colorFromQuality", because I can't find a function in gca_tools that returns the hex color.

I can create it if you think it's best, instead of duplicating this forging and smelting logic.