### PR TITLE
Global Arena logo + description style

### DIFF
--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1200,7 +1200,7 @@
 		.gca_arena-simulator-img div{color:#fff;text-align: center;text-shadow: 0px 0px 2px black;padding-top: 4px;}
 		
 		/* Global Arena */
-		.global_arena_header{background-image: url('images/colosseo_by_Dario_Veronesi_unsplash.jpg');background-size: cover;background-repeat: no-repeat;background-position: center center;height: 100px;color: rgba(255, 152, 0, 0.9)!important;font-size: 20px;text-align: center!important;font-size:20px!important;line-height: 100px;font-family: century gothic;text-shadow: 0px 0px 4px #000;}
+		.global_arena_header{background-image: url('images/colosseo_by_Dario_Veronesi_unsplash.jpg');background-size: cover;background-repeat: no-repeat;background-position: center center;height: 100px;color: rgba(255, 152, 0, 0.9)!important;font-size: 20px!important;text-align: center!important;line-height: 100px;font-family: century gothic;text-shadow: 0px 0px 4px #000;}
 		#global_arena_box .flag{height: 12px;width:20px;}
 		#global_arena_box #alert_box{text-align: center;font-size: 14px;font-weight: bold;}
 		#global_arena_box #spiner_box{display:none;width: 500px;position: absolute;line-height:100%;}

--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1200,7 +1200,7 @@
 		.gca_arena-simulator-img div{color:#fff;text-align: center;text-shadow: 0px 0px 2px black;padding-top: 4px;}
 		
 		/* Global Arena */
-		.global_arena_header{background-image: url('images/colosseo_by_Dario_Veronesi_unsplash.jpg');background-size: cover;background-repeat: no-repeat;background-position: center center;height: 100px;color: rgba(255, 152, 0, 0.9);font-size: 20px;text-align: center;line-height: 100px;font-family: century gothic;text-shadow: 0px 0px 4px #000;}
+		.global_arena_header{background-image: url('images/colosseo_by_Dario_Veronesi_unsplash.jpg');background-size: cover;background-repeat: no-repeat;background-position: center center;height: 100px;color: rgba(255, 152, 0, 0.9)!important;font-size: 20px;text-align: center!important;font-size:20px!important;line-height: 100px;font-family: century gothic;text-shadow: 0px 0px 4px #000;}
 		#global_arena_box .flag{height: 12px;width:20px;}
 		#global_arena_box #alert_box{text-align: center;font-size: 14px;font-weight: bold;}
 		#global_arena_box #spiner_box{display:none;width: 500px;position: absolute;line-height:100%;}

--- a/source/core/source/arena.js
+++ b/source/core/source/arena.js
@@ -138,7 +138,7 @@ var gca_arena = {
 			// Add text
 			let description = document.createElement('p');
 			description.textContent = gca_locale.get("arena", "global_arena_description")+" ";
-			description.style = "text-align: justify;";
+			description.style = "text-align: center;";
 			box.appendChild(description);
 
 			// Add link to highscore


### PR DESCRIPTION
Without the use of `!important`, the browser does not respect the css rules, and was using the Gladiatus styles.

Also, you don't have to use that `text-align: center` if you don't like it, personally, I think it looks much better like this all together. You don't have to merge this and do the `!important` changes yourself if you want to style it yourself, the logo font color can also be changed to white or `#bfae54` (the main menu font color), but I left it original and it's not bad.

**OLD**
![old](https://user-images.githubusercontent.com/23278552/177221535-7b071d6a-cbd0-4a84-973c-d16a86c60d68.PNG)

**NEW**
![new](https://user-images.githubusercontent.com/23278552/177221538-7f6fb97c-45c5-4b94-99ef-ca469d68f180.PNG)