### PR TITLE
Auctions - show item level disabled

### DIFF
--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1203,9 +1203,10 @@
 	/* Auction
 	-------------------------------------------------- */
 
-		/* Level indicator */
+		/* Level indicator (disabled)
 		.gca_auction .gca_item_level{float: right;width: 16px;height: 16px;color: white;cursor: default;font-size: 9px;line-height: 17px;text-align: center;margin: 2px;}
 		.gca_rtl .gca_auction .gca_item_level{float: left;}
+                */
 
 		/* Item value info */
 		.gca_auction .gca-auction-good-price,

--- a/source/core/source/auction.js
+++ b/source/core/source/auction.js
@@ -20,8 +20,8 @@ var gca_auction = {
 				this.itemsShadow());
 			(gca_options.bool("auction","item_price_analyze") && 
 				this.itemsValuesShow());
-			(gca_options.bool("auction","item_level") && 
-				this.itemsLevelShow());
+			/* (gca_options.bool("auction","item_level") && 
+				this.itemsLevelShow()); */
 			(gca_options.bool("auction","item_name") && 
 				this.itemsNameShow());
 			(gca_options.bool("auction","x3_items_per_line") && 
@@ -233,7 +233,9 @@ var gca_auction = {
 			wrapper.insertBefore(indicator, wrapper.children[2]);
 		}
 	},
-
+        
+	/*
+        //Item levels are shown on the items it self, feature is no longer needed
 	itemsLevelShow : function() {
 		// Get items
 		var items = document.getElementById("auction_table").getElementsByClassName("auction_item_div");
@@ -256,6 +258,7 @@ var gca_auction = {
 			wrapper.insertBefore(indicator, wrapper.firstChild);
 		}
 	},
+	*/
 
 	extraItemStats : function() {
 		// Run on food section

--- a/source/core/source/gca.data.js
+++ b/source/core/source/gca.data.js
@@ -613,8 +613,8 @@ gca_options.data = {
 		"more_search_levels" : false,
 		// Show price data
 		"item_price_analyze" : true,
-		// Show item level
-		"item_level" : true,
+		// Show item level (disabled)
+		/*"item_level" : false, */
 		// Show item names
 		"item_name" : false,
 		// Show 3 items per line

--- a/source/core/source/settings.js
+++ b/source/core/source/settings.js
@@ -1091,9 +1091,9 @@ var gca_settings = {
 				// More search levels
 				"more_search_levels" : true,
 				// Show price data
-				"item_price_analyze" : true,
-				// Show item level
-				"item_level" : true,
+				"item_price_analyze" : true,			
+				// Show item level (disabled)
+				/*"item_level" : false, */				
 				// Show item names
 				"item_name" : false,
 				// Show 3 items per line


### PR DESCRIPTION
Apo or Thanos, do you approve? Mentioned it #308, feature is useless now so it doesn't have to be loaded every time. I know you don't like to remove stuff completely, so I only disabled it.