### PR TITLE
Gladiatus fixes optional

### DIFF
--- a/source/core/locale/en.js
+++ b/source/core/locale/en.js
@@ -385,6 +385,7 @@ gca_languages["en"] = {
 			category_global$show_mercenaries_real_name_and_combat_stats : "Display mercenaries real names (type) and combat stats on tooltips",
 			category_global$show_upgrade_values : "Display buff values on reinforcements & upgrades",
 			category_global$global_arena_timer : "Display Global Arena timer",
+			category_global$gladiatus_site_fixes : "Fix Gladiatus site style problems",
 			// Settings - Overview
 			category_overview$analyze_items : "Analyze items stats (needed for training)",
 			category_overview$food_life_gain : "Show life gain from foods",

--- a/source/core/locale/en.js
+++ b/source/core/locale/en.js
@@ -385,7 +385,7 @@ gca_languages["en"] = {
 			category_global$show_mercenaries_real_name_and_combat_stats : "Display mercenaries real names (type) and combat stats on tooltips",
 			category_global$show_upgrade_values : "Display buff values on reinforcements & upgrades",
 			category_global$global_arena_timer : "Display Global Arena timer",
-			category_global$gladiatus_site_fixes : "Fix Gladiatus site style problems",
+			category_global$gladiatus_site_fixes : "Fix and improve Gladiatus site style problems",
 			// Settings - Overview
 			category_overview$analyze_items : "Analyze items stats (needed for training)",
 			category_overview$food_life_gain : "Show life gain from foods",

--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1591,27 +1591,27 @@
 	-------------------------------------------------- */
 
 		/* Highscore tables reposition */
-		.glfix, #highscorePage .section-like {margin-left: -19px;width: 555px!important;max-width: 560px;}
-		.glfix, #highscorePage .section-like.narrow th, table.section-like.narrow td {padding: 3px!important;} 
+		.glfix  #highscorePage .section-like {margin-left: -19px;width: 555px!important;max-width: 560px;}
+		.glfix  #highscorePage .section-like.narrow th, table.section-like.narrow td {padding: 3px!important;} 
 		/* Inventory tabs moved by 1px */
-		.glfix, #inventory_nav {left: 23px!important;}
+		.glfix  #inventory_nav {left: 23px!important;}
 		/* Broken line in header links with various languages */
-		.glfix, #header_game>span, #header_game>span a {margin-right: 8px!important;}
+		.glfix  #header_game>span, #header_game>span a {margin-right: 8px!important;}
 		/* Menu text breaking the line with various languages */
-		.glfix, #mainmenu a {white-space: nowrap;overflow: hidden;text-overflow: ellipsis;}
-		.glfix, #mainmenu a:hover {overflow: visible;}
+		.glfix  #mainmenu a {white-space: nowrap;overflow: hidden;text-overflow: ellipsis;}
+		.glfix  #mainmenu a:hover {overflow: visible;}
 		/* UW Slider style problems with your avatar */
-		.glfix, .underworld #expedition_info1 {min-height: 241px;}
+		.glfix  .underworld #expedition_info1 {min-height: 241px;}
                 /* Custom scrollbar */		
-                .glfix, ::-webkit-scrollbar {width: 16px;}
-                .glfix, ::-webkit-scrollbar-track {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
-                .glfix, ::-webkit-scrollbar-thumb {background: linear-gradient(to bottom, #C3AB6F, #886933);border-radius: 5px; border: 1px solid #4A3615;}
-                .glfix, ::-webkit-scrollbar-thumb:hover {background: linear-gradient(to bottom, #D6BC78 , #A27E3E);}
-                .glfix, ::-webkit-scrollbar-corner {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
+                .glfix  ::-webkit-scrollbar {width: 16px;}
+                .glfix  ::-webkit-scrollbar-track {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
+                .glfix  ::-webkit-scrollbar-thumb {background: linear-gradient(to bottom, #C3AB6F, #886933);border-radius: 5px; border: 1px solid #4A3615;}
+                .glfix  ::-webkit-scrollbar-thumb:hover {background: linear-gradient(to bottom, #D6BC78 , #A27E3E);}
+                .glfix  ::-webkit-scrollbar-corner {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
                 /* Custom scrollbar for Firefox */
-                .glfix, html {scrollbar-color: #a88d54 #290d03; scrollbar-width: 16px;}
+                .glfix  html {scrollbar-color: #a88d54 #290d03; scrollbar-width: 16px;}
                 /* Buff side-icons incomplete */
-                .glfix, .buff {display: block!important;} 
+                .glfix  .buff {display: block!important;} 
 
 	/* Ester Eggs
 	-------------------------------------------------- */

--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1602,16 +1602,16 @@
 		.glfix #mainmenu a:hover {overflow: visible;}
 		/* UW Slider style problems with your avatar */
 		.glfix .underworld #expedition_info1 {min-height: 241px;}
-    /* Custom scrollbar */		
-    .glfix ::-webkit-scrollbar {width: 16px;}
-    .glfix ::-webkit-scrollbar-track {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
-    .glfix ::-webkit-scrollbar-thumb {background: linear-gradient(to bottom, #C3AB6F, #886933);border-radius: 5px; border: 1px solid #4A3615;}
-    .glfix ::-webkit-scrollbar-thumb:hover {background: linear-gradient(to bottom, #D6BC78 , #A27E3E);}
-    .glfix ::-webkit-scrollbar-corner {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
-    /* Custom scrollbar for Firefox */
-    .glfix html {scrollbar-color: #a88d54 #290d03; scrollbar-width: 16px;}
-    /* Buff side-icons incomplete */
-    .glfix .buff {display: block!important;} 
+                /* Custom scrollbar */		
+                .glfix ::-webkit-scrollbar {width: 16px;}
+                .glfix ::-webkit-scrollbar-track {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
+                .glfix ::-webkit-scrollbar-thumb {background: linear-gradient(to bottom, #C3AB6F, #886933);border-radius: 5px; border: 1px solid #4A3615;}
+                .glfix ::-webkit-scrollbar-thumb:hover {background: linear-gradient(to bottom, #D6BC78 , #A27E3E);}
+                .glfix ::-webkit-scrollbar-corner {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
+                /* Custom scrollbar for Firefox */
+                .glfix html {scrollbar-color: #a88d54 #290d03; scrollbar-width: 16px;}
+                /* Buff side-icons incomplete */
+                .glfix .buff {display: block!important;} 
 
 	/* Ester Eggs
 	-------------------------------------------------- */

--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1591,17 +1591,17 @@
 	-------------------------------------------------- */
 
 		/* Highscore tables reposition */
-		#glfix, #highscorePage .section-like {margin-left: -19px;width: 555px!important;max-width: 560px;}
-		#glfix, #highscorePage .section-like.narrow th, table.section-like.narrow td {padding: 3px!important;} 
+		.glfix, #highscorePage .section-like {margin-left: -19px;width: 555px!important;max-width: 560px;}
+		.glfix, #highscorePage .section-like.narrow th, table.section-like.narrow td {padding: 3px!important;} 
 		/* Inventory tabs moved by 1px */
-		#glfix, #inventory_nav {left: 23px!important;}
+		.glfix, #inventory_nav {left: 23px!important;}
 		/* Broken line in header links with various languages */
-		#glfix, #header_game>span, #header_game>span a {margin-right: 8px!important;}
+		.glfix, #header_game>span, #header_game>span a {margin-right: 8px!important;}
 		/* Menu text breaking the line with various languages */
-		#glfix, #mainmenu a {white-space: nowrap;overflow: hidden;text-overflow: ellipsis;}
-		#glfix, #mainmenu a:hover {overflow: visible;}
+		.glfix, #mainmenu a {white-space: nowrap;overflow: hidden;text-overflow: ellipsis;}
+		.glfix, #mainmenu a:hover {overflow: visible;}
 		/* UW Slider style problems with your avatar */
-		#glfix, .underworld #expedition_info1 {min-height: 241px;}
+		.glfix, .underworld #expedition_info1 {min-height: 241px;}
 
 	/* Ester Eggs
 	-------------------------------------------------- */

--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1610,6 +1610,8 @@
                 .glfix, ::-webkit-scrollbar-corner {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
                 /* Custom scrollbar for Firefox */
                 .glfix, html {scrollbar-color: #a88d54 #290d03; scrollbar-width: 16px;}
+                /* Buff side-icons incomplete */
+                .glfix, .buff {display: block!important;} 
 
 	/* Ester Eggs
 	-------------------------------------------------- */

--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1591,17 +1591,17 @@
 	-------------------------------------------------- */
 
 		/* Highscore tables reposition */
-		#highscorePage .section-like {margin-left: -19px;width: 555px!important;max-width: 560px;}
-		#highscorePage .section-like.narrow th, table.section-like.narrow td {padding: 3px!important;} 
+		#glfix, #highscorePage .section-like {margin-left: -19px;width: 555px!important;max-width: 560px;}
+		#glfix, #highscorePage .section-like.narrow th, table.section-like.narrow td {padding: 3px!important;} 
 		/* Inventory tabs moved by 1px */
-		#inventory_nav {left: 23px!important;}
+		#glfix, #inventory_nav {left: 23px!important;}
 		/* Broken line in header links with various languages */
-		#header_game>span, #header_game>span a {margin-right: 8px!important;}
+		#glfix, #header_game>span, #header_game>span a {margin-right: 8px!important;}
 		/* Menu text breaking the line with various languages */
-		#mainmenu a {white-space: nowrap;overflow: hidden;text-overflow: ellipsis;}
-		#mainmenu a:hover {overflow: visible;}
+		#glfix, #mainmenu a {white-space: nowrap;overflow: hidden;text-overflow: ellipsis;}
+		#glfix, #mainmenu a:hover {overflow: visible;}
 		/* UW Slider style problems with your avatar */
-		.underworld #expedition_info1 {min-height: 241px;}
+		#glfix, .underworld #expedition_info1 {min-height: 241px;}
 
 	/* Ester Eggs
 	-------------------------------------------------- */

--- a/source/core/resources/style_gca.css
+++ b/source/core/resources/style_gca.css
@@ -1602,6 +1602,14 @@
 		.glfix, #mainmenu a:hover {overflow: visible;}
 		/* UW Slider style problems with your avatar */
 		.glfix, .underworld #expedition_info1 {min-height: 241px;}
+                /* Custom scrollbar */		
+                .glfix, ::-webkit-scrollbar {width: 16px;}
+                .glfix, ::-webkit-scrollbar-track {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
+                .glfix, ::-webkit-scrollbar-thumb {background: linear-gradient(to bottom, #C3AB6F, #886933);border-radius: 5px; border: 1px solid #4A3615;}
+                .glfix, ::-webkit-scrollbar-thumb:hover {background: linear-gradient(to bottom, #D6BC78 , #A27E3E);}
+                .glfix, ::-webkit-scrollbar-corner {background: linear-gradient(to right, #290d03, #290d03, #33170D, #33170D);}
+                /* Custom scrollbar for Firefox */
+                .glfix, html {scrollbar-color: #a88d54 #290d03; scrollbar-width: 16px;}
 
 	/* Ester Eggs
 	-------------------------------------------------- */

--- a/source/core/source/gca.data.js
+++ b/source/core/source/gca.data.js
@@ -373,7 +373,10 @@ gca_options.data = {
 		"show_upgrade_values" : false,
 		
 		// Global Arena timer
-		"global_arena_timer" : true
+		"global_arena_timer" : true,
+		
+		// Gladiatus site fixes
+		"gladiatus_site_fixes" : true
 	},
 
 	// Overview Options

--- a/source/core/source/global.js
+++ b/source/core/source/global.js
@@ -28,6 +28,9 @@ var gca_global = {
 		// If submenu click to change
 		(gca_options.bool("global","submenu_click_to_change") && 
 			this.display.advanced_main_menu.submenuClickToChangeTab.preload());
+		// Gladiatus site fixes & improvements
+		(gca_options.bool("global","gladiatus_site_fixes") && 
+			this.display.gladiatus_site_fixes.preload());
 		// If rtl server
 		if (localStorage.getItem('gca_rtl')) {
 			document.documentElement.classList.add("gca_rtl");
@@ -1925,6 +1928,14 @@ var gca_global = {
 					gca_data.section.set("cache", "event_bar_active", 0);
 					document.documentElement.className = document.documentElement.className.replace(/\s*event_bar_moved\s*/i, " ");
 				}
+			}
+		},
+		
+		// Gladiatus site fixes & improvements
+		gladiatus_site_fixes : {
+			preload : function(){
+				// Insert it on html tag
+				document.documentElement.className += " glfix";
 			}
 		},
 

--- a/source/core/source/settings.js
+++ b/source/core/source/settings.js
@@ -732,6 +732,9 @@ var gca_settings = {
 				
 				// Attacked Timer
 				"global_arena_timer" : true,
+				
+		                // Gladiatus site fixes
+		                "gladiatus_site_fixes" : true				
 			},
 
 			// Overview Options


### PR DESCRIPTION
When I have done some Gladiatus site style fixes, I knew about it, and then Thanos also mentioned - these can backfire, I am aware of it, so, I was thinking and I believe it would be wise, to be able to turn them off if they cause any troubles (but I think they can stay enabled by default).

Now, this pull request isn't complete, it's missing the script itself, that's the job for the Greek Javascript gods, I was looking into some options on stackoverflow and into GCA scripts, but I am 100% sure, that even if I somehow made it, Thanos would rework the code (which is by the way, completely understandable), so I end up with this.

I need you, to implement this into **global.js**, basically the script should apply this set of CSS rules when enabled, it should probably be easy for you. I have prepared the basics to save you the time.

I've marked the CSS with ID `#glfix` (but you can also use class, it depends on your implementation), under the locales and settings, it's known as `"gladiatus_site_fixes"`. Well, you can see the changes made for yourself.

Thank you for the help 😄 

