### PR TITLE
Add CTRL key modifier for +100 training increment

### DIFF
--- a/source/core/source/training.js
+++ b/source/core/source/training.js
@@ -253,11 +253,11 @@ var gca_training = {
 				data.count = 1;
 
 				// Events
-				this.addIncrementEvent(data.arrowUp, () => {
-					this.add( 1, data);
+				this.addIncrementEvent(data.arrowUp, (e) => {
+					this.add(e.ctrlKey ?  100 :  1, data);
 				}, 200);
-				this.addIncrementEvent(data.arrowDown, () => {
-					this.add(-1, data);
+				this.addIncrementEvent(data.arrowDown, (e) => {
+					this.add(e.ctrlKey ? -100 : -1, data);
 				}, 200);
 
 				// Update display data


### PR DESCRIPTION
While increasing/decreasing training points by clicking the arrows, now while holding down the CTRL key, each click increases/decreases points by 100 instead of 1 point.