### PR TITLE
fix: missing percentage in costs_discount in pt

### DIFF
--- a/source/core/locale/pt.js
+++ b/source/core/locale/pt.js
@@ -199,7 +199,7 @@ gca_languages['pt'] = {
 			// Cost calculator
 			total_cost : "Custo total",
 			// Discount show
-			costs_discount : "Desconto nos custos de treino"
+			costs_discount : "Desconto nos custos de treino: {number}}%"
 		},
 		
 		// Auction section


### PR DESCRIPTION
In the Portuguese locale, the percentage is missing in cost discount 
<img width="539" alt="image" src="https://github.com/DinoDevs/GladiatusCrazyAddon/assets/31651353/1f3f5abf-5f22-4352-b3bc-27dc9e3afe73">
